### PR TITLE
Correct the Content-Disposition Header for preview image, in order to…

### DIFF
--- a/server.py
+++ b/server.py
@@ -420,7 +420,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"filename=\"{filename.replace('png', image_format)}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'


### PR DESCRIPTION
… download as correct filename

To avoid download a webp preview image with a '.png' filename